### PR TITLE
Use a UTF-8 locale in tox so ansible-lint can run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ usedevelop = True
 install_command = pip install {opts} {packages}
 setenv =
     VIRTUAL_ENV={envdir}
-    LANG=en_US.UTF-8
+    LANG=C.UTF-8
     LANGUAGE=en_US:en
-    LC_ALL=C
+    LC_ALL=C.UTF-8
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
`otc-tox-linters` fails in the eco2 tenant with:

```
ERROR: Ansible requires the locale encoding to be UTF-8; Detected None.
ERROR: InvocationError for command .../ansible-lint (exited with code 1)
```

Ansible checks `locale.getlocale()[1]`. Reproduced in a live build pod:

```
LC_ALL=C        -> getlocale()[1] = None      <- 'Detected None'
LC_ALL=C.UTF-8  -> getlocale()[1] = 'UTF-8'   <- OK
```

`LC_ALL` overrides `LANG`, so the `LANG` line in `setenv` never took effect. It was also set to `en_US.UTF-8`, which is not generated in the build image (only `C`, `C.utf8`, `POSIX`), so simply dropping `LC_ALL` would fail too. Both are set to `C.UTF-8`.

This is not an image problem - the pod already exports `LANG=C.UTF-8`; the tox `setenv` was discarding it.